### PR TITLE
Enforced updating of cohort tables during previewing/loading and highlighted current case in cohort table during session

### DIFF
--- a/CART/CART.py
+++ b/CART/CART.py
@@ -593,13 +593,13 @@ class CARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
       # Disable buttons if in task mode
       if self.isTaskMode:
-        self.previewButton.setEnabled(False)
-        self.confirmButton.setEnabled(False)
+          self.previewButton.setEnabled(False)
+          self.confirmButton.setEnabled(False)
 
       # Disable navigation buttons if only in preview mode
       if self.isPreviewMode and not self.isTaskMode:
-        self.previousButton.setEnabled(False)
-        self.nextButton.setEnabled(False)
+          self.previousButton.setEnabled(False)
+          self.nextButton.setEnabled(False)
 
       # Always (re)build the table if in preview or task mode
       self.buildCohortTable()
@@ -700,7 +700,7 @@ class CARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         # If the logic says we're ready to start, we can start
         if self.logic.is_ready():
             self.confirmButton.setEnabled(True)
-          
+                    
     def loadTaskWhenReady(self):
         # If we're not ready to load a task, leave everything untouched
         if not self.logic.is_ready():

--- a/CART/CARTLib/core/DataManager.py
+++ b/CART/CARTLib/core/DataManager.py
@@ -104,11 +104,12 @@ class DataManager:
         if we recently created it, instead using the cached version instead.
         """
         current_case_data = self.case_data[idx]
-        # TODO: replace this with a user-selectable data unit type
         
+        # TODO: replace this with a user-selectable data unit type
         return VolumeOnlyDataUnit(
             data=current_case_data,
-            data_path=self.data_source)
+            data_path=self.data_source
+          )
         
 
     def current_uid(self):


### PR DESCRIPTION
- disables preview and confirm buttons if confirm has already been clicked. 
- fixes duplication of cohort tables depending on preview workflow #10 
- highlights current cohort in the table upon task started #16 