### PR TITLE
Configuration Refactor and Extension

### DIFF
--- a/CART/CART.py
+++ b/CART/CART.py
@@ -12,7 +12,7 @@ from slicer.ScriptedLoadableModule import *
 from slicer.i18n import tr as _
 from slicer.util import VTKObservationMixin
 
-from CARTLib.utils.config import config, UserConfig
+from CARTLib.utils.config import GLOBAL_CONFIG, UserConfig
 from CARTLib.core.DataManager import DataManager
 from CARTLib.core.DataUnitBase import DataUnitBase
 from CARTLib.core.TaskBaseClass import TaskBaseClass, DataUnitFactory
@@ -85,7 +85,7 @@ class CART(ScriptedLoadableModule):
         )
 
         # Load our configuration
-        config.load()
+        GLOBAL_CONFIG.load()
 
         # Add CARTLib to the Python Path for ease of (re-)use
         import sys
@@ -1077,7 +1077,7 @@ class CARTLogic(ScriptedLoadableModuleLogic):
         self.data_unit_factory: Optional[DataUnitFactory] = None
 
         # Load our last state from the config file
-        self._load_user_state(config.last_user)
+        self._load_user_state(GLOBAL_CONFIG.last_user)
 
     ## User Management ##
     @property
@@ -1092,7 +1092,7 @@ class CARTLogic(ScriptedLoadableModuleLogic):
         if not stripped_name:
             raise ValueError("Cannot set the active user to blank!")
 
-        if not stripped_name in config.profiles.keys():
+        if not stripped_name in GLOBAL_CONFIG.profiles.keys():
             raise ValueError(f"Cannot select user '{stripped_name}'; they don't have a profile!")
 
         # Set the user's profile as our own
@@ -1105,7 +1105,7 @@ class CARTLogic(ScriptedLoadableModuleLogic):
         self.clear_task()
 
         # Update the config to designate that this user is now the most recent
-        config.last_user = stripped_name
+        GLOBAL_CONFIG.last_user = stripped_name
 
     def _load_user_state(self, username: str):
         """
@@ -1116,7 +1116,7 @@ class CARTLogic(ScriptedLoadableModuleLogic):
             raise ValueError("Cannot load a blank user!")
 
         # Try to load that user's configuration
-        self.config = config.get_user_config(username)
+        self.config = GLOBAL_CONFIG.get_user_config(username)
 
         # If that config is empty, terminate here
         if not self.config:
@@ -1130,7 +1130,7 @@ class CARTLogic(ScriptedLoadableModuleLogic):
 
     def get_available_usernames(self) -> list[str]:
         # Simple wrapper for our config
-        return [str(x) for x in config.profiles.keys()]
+        return [str(x) for x in GLOBAL_CONFIG.profiles.keys()]
 
     def new_user_profile(self, username: str) -> UserConfig:
         """
@@ -1140,7 +1140,7 @@ class CARTLogic(ScriptedLoadableModuleLogic):
         We also immediately change to this new profile to give the
         user some feedback
         """
-        new_profile = config.new_user_profile(username, self.config)
+        new_profile = GLOBAL_CONFIG.new_user_profile(username, self.config)
         self._load_user_state(username)
         return new_profile
 

--- a/CART/CART.py
+++ b/CART/CART.py
@@ -902,7 +902,7 @@ class CARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                 # Build the Task GUI, using the prior widget as a foundation
                 self.logic.current_task_instance.setup(self.dummyTaskWidget)
                 # Add the widget to our layout
-                self.taskGUI._layout().addWidget(self.dummyTaskWidget)
+                self.taskGUI.layout().addWidget(self.dummyTaskWidget)
 
                 # Expand the task GUI, if it wasn't already
                 self.taskGUI.collapsed = False

--- a/CART/CART.py
+++ b/CART/CART.py
@@ -85,7 +85,7 @@ class CART(ScriptedLoadableModule):
         )
 
         # Load our configuration
-        GLOBAL_CONFIG.load()
+        GLOBAL_CONFIG.load_from_json()
 
         # Add CARTLib to the Python Path for ease of (re-)use
         import sys
@@ -1359,7 +1359,7 @@ class CARTLogic(ScriptedLoadableModuleLogic):
 
         # Save any changes made to the configuration
         # (Usually saves the user and
-        self.config.save_to_file()
+        self.config.save()
 
         # Act as though CART has just been reloaded so the task can initialize
         #  properly

--- a/CART/CART.py
+++ b/CART/CART.py
@@ -389,6 +389,9 @@ class CARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         configButton = qt.QPushButton(_("Configure"))
         configButton.toolTip = _("Change how CART is configured to iterate through your data.")
 
+        # Clicking the config button shows the Config prompt
+        configButton.clicked.connect(config.show_gui)
+
         # A button which confirms the current settings and attempts to start
         #  task iteration!
         confirmButton = qt.QPushButton(_("Confirm"))
@@ -899,7 +902,7 @@ class CARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                 # Build the Task GUI, using the prior widget as a foundation
                 self.logic.current_task_instance.setup(self.dummyTaskWidget)
                 # Add the widget to our layout
-                self.taskGUI.layout().addWidget(self.dummyTaskWidget)
+                self.taskGUI._layout().addWidget(self.dummyTaskWidget)
 
                 # Expand the task GUI, if it wasn't already
                 self.taskGUI.collapsed = False

--- a/CART/CART.py
+++ b/CART/CART.py
@@ -385,6 +385,10 @@ class CARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         # Disable the button by default; we need a valid cohort first!
         previewButton.setEnabled(False)
 
+        # A button to open the Configuration dialog, which changes how CART operates
+        configButton = qt.QPushButton(_("Configure"))
+        configButton.toolTip = _("Change how CART is configured to iterate through your data.")
+
         # A button which confirms the current settings and attempts to start
         #  task iteration!
         confirmButton = qt.QPushButton(_("Confirm"))
@@ -396,11 +400,15 @@ class CARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         # Attempt to load the task, assuming everything is ready
         confirmButton.clicked.connect(self.loadTaskWhenReady)
 
-        # Add them to our layout
-        mainLayout.addRow(previewButton, confirmButton)
+        # Place them equally spaced in a single row
+        buttonLayout = qt.QHBoxLayout()
+        for b in [previewButton, configButton, confirmButton]:
+            buttonLayout.addWidget(b)
+        mainLayout.addRow(buttonLayout)
 
         # Make them accessible
         self.previewButton = previewButton
+        self.configButton = configButton
         self.confirmButton = confirmButton
 
     def buildCaseIteratorUI(self, mainLayout: qt.QFormLayout):

--- a/CART/CART.py
+++ b/CART/CART.py
@@ -1355,7 +1355,7 @@ class CARTLogic(ScriptedLoadableModuleLogic):
 
         # Create the new task instance
         task_constructor = self.task_map.get(self.task_id)
-        self.current_task_instance = task_constructor(self.active_username)
+        self.current_task_instance = task_constructor(self.config)
 
         # Save any changes made to the configuration
         # (Usually saves the user and

--- a/CART/CART.py
+++ b/CART/CART.py
@@ -1197,6 +1197,9 @@ class CARTLogic(ScriptedLoadableModuleLogic):
 
         # If that all ran, update our state
         self._data_path = new_path
+
+        # Reset our state, as the task + data manager is likely no longer valid
+        self.clear_task()
         self.rebuild_data_manager()
 
         # Update the config to match

--- a/CART/CART.py
+++ b/CART/CART.py
@@ -1137,8 +1137,8 @@ class CARTLogic(ScriptedLoadableModuleLogic):
         # Try to load that user's configuration
         self.config = GLOBAL_CONFIG.get_user_config(username)
 
-        # If that config is empty, terminate here
-        if not self.config:
+        # If there is not corresponding config, terminate here
+        if self.config is None:
             raise ValueError(f"No profile exists for username '{username}'")
 
         # Try to synchronize the config's state with our own

--- a/CART/CART.py
+++ b/CART/CART.py
@@ -511,18 +511,22 @@ class CARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     ### Setup Widgets ###
     def promptNewUser(self):
         """
-        Creates a pop-up, prompting the user to enter their name into a
-        text box to register themselves as a new user.
-        """
-        # Create a new widget
-        new_name = qt.QInputDialog().getText(
-            self.mainGUI, _("Add New User"), _("New User Name:")
-        )
+        Prompt the user to fill out details for a new user profile.
 
-        # Attempt to add the new user to the Logic
+        If successful, also updates the logic to match
+        """
         try:
-            self.logic.new_user_profile(new_name)
-            self.sync_with_logic()
+            # Get the username for the new user profile; None if no
+            # user was created.
+            new_username = GLOBAL_CONFIG.promptNewUser(
+                self.logic.config
+            )
+            # If a valid username was returned, update our logic to match
+            if new_username:
+                self.logic.active_username = new_username
+                self.sync_with_logic()
+                # Save the config to entrench this new state
+                GLOBAL_CONFIG.save()
         except Exception as exc:
             self.pythonExceptionPrompt(exc)
 
@@ -1156,7 +1160,10 @@ class CARTLogic(ScriptedLoadableModuleLogic):
         We also immediately change to this new profile to give the
         user some feedback
         """
-        new_profile = GLOBAL_CONFIG.new_user_profile(username, self.config)
+        # We always copy from the current profile by default
+        new_profile = GLOBAL_CONFIG.new_user_profile(
+            username, reference_profile=self.config
+        )
         self._load_user_state(username)
         return new_profile
 

--- a/CART/CART.py
+++ b/CART/CART.py
@@ -1398,8 +1398,8 @@ class CARTLogic(ScriptedLoadableModuleLogic):
             return
 
         # If autosaving is on, have the task save its current case before proceeding
-        if config.autosave:
-            task.autosave()
+        if config.save_on_iter:
+            task.save_on_iter()
 
         # Have the task receive the new case
         task.receive(new_case)

--- a/CART/CART.py
+++ b/CART/CART.py
@@ -1358,7 +1358,6 @@ class CARTLogic(ScriptedLoadableModuleLogic):
         self.current_task_instance = task_constructor(self.config)
 
         # Save any changes made to the configuration
-        # (Usually saves the user and
         self.config.save()
 
         # Act as though CART has just been reloaded so the task can initialize

--- a/CART/CART.py
+++ b/CART/CART.py
@@ -1048,7 +1048,7 @@ class CARTLogic(ScriptedLoadableModuleLogic):
         self._data_path: Path = None
 
         # The data manager currently managing case iteration
-        self.data_manager: Optional[DataManager] = None
+        self._data_manager: Optional[DataManager] = None
 
         # The currently selected task Label
         self._task_id: str = None
@@ -1360,13 +1360,17 @@ class CARTLogic(ScriptedLoadableModuleLogic):
             self.current_task_instance.exit()
 
     ## DataUnit Management ##
+    @property
+    def data_manager(self):
+        return self._data_manager
+
     def rebuild_data_manager(self):
         # If we had a prior data manager, clean it up first
         if self.data_manager:
             self.data_manager.clean()
 
         # Build a new data manager with the current state
-        self.data_manager = DataManager(
+        self._data_manager = DataManager(
             cohort_file=self._cohort_path,
             data_source=self._data_path,
             data_unit_factory=self.data_unit_factory,

--- a/CART/CART.py
+++ b/CART/CART.py
@@ -1269,11 +1269,12 @@ class CARTLogic(ScriptedLoadableModuleLogic):
         # Get this task's preferred DataUnitFactory method
         # TODO: Allow the user to select the specific method, rather than always
         #  using the first in the map
-        data_factory_method_map = task_type.getDataUnitFactories()
-        duf = list(data_factory_method_map.values())[0]
+        if task_type:
+            data_factory_method_map = task_type.getDataUnitFactories()
+            duf = list(data_factory_method_map.values())[0]
 
-        # Update the data manager to use this task's preferred DataUnitFactory
-        self.data_unit_factory = duf
+            # Update the data manager to use this task's preferred DataUnitFactory
+            self.data_unit_factory = duf
 
     @property
     def has_active_task(self) -> bool:

--- a/CART/CARTLib/core/TaskBaseClass.py
+++ b/CART/CARTLib/core/TaskBaseClass.py
@@ -105,18 +105,22 @@ class TaskBaseClass(ABC, Generic[D]):
 
         raise NotImplementedError("save must be implemented in subclasses")
 
-    def autosave(self) -> Optional[str]:
+    def save_on_iter(self) -> Optional[str]:
         """
-        Called when the task is asked to auto-save, either due to the case being
-        changed or through periodic auto-saving. By default, just saves as normal;
-        overwrite if you want some custom functionality to be run in this context.
+        Called when the task is asked to save due to the case being changed.
+
+        By default, just saves as normal; overwrite if you want some custom
+        functionality to be run in this context.
 
         Returns None on a successful save; otherwise, return an error message
         describing what went wrong.
         """
-        print("Autosaving...")
-        self.save()
-        print("Auto-save was successful!")
+        print("Saving...")
+        save_result = self.save()
+        if not save_result:
+            print("Iteration save was successful!")
+        else:
+            raise ValueError(f"An error occurred during saving: {save_result}")
 
     def isTaskComplete(self, case_data: dict[str: str]) -> bool:
         """

--- a/CART/CARTLib/core/TaskBaseClass.py
+++ b/CART/CARTLib/core/TaskBaseClass.py
@@ -7,6 +7,7 @@ import qt
 import slicer
 
 from CARTLib.core.DataUnitBase import DataUnitBase
+from CARTLib.utils.config import UserConfig
 
 # Generic type hint class for anything which is a subclass of DataUnitBase
 D = TypeVar("D", bound=DataUnitBase)
@@ -37,7 +38,7 @@ class TaskBaseClass(ABC, Generic[D]):
     itself.!
     """
 
-    def __init__(self, user: str):
+    def __init__(self, user: UserConfig):
         """
         Basic constructor.
 
@@ -49,10 +50,19 @@ class TaskBaseClass(ABC, Generic[D]):
         """
         # Track the user for later; we often want to stratify our task by which
         #  user is running it
-        self.user = user
+        self.user: UserConfig = user
 
         # Create a logger to track the goings-on of this task.
         self.logger = logging.getLogger(f"{__class__.__name__}")
+
+    # Aliases for commonly accessed attributes
+    @property
+    def username(self) -> str:
+        return self.user.username
+
+    @property
+    def user_role(self) -> str:
+        return self.user.role
 
     @abstractmethod
     def setup(self, container: qt.QWidget):

--- a/CART/CARTLib/examples/MultiContrastSegmentation/MultiContrastSegmentationConfig.py
+++ b/CART/CARTLib/examples/MultiContrastSegmentation/MultiContrastSegmentationConfig.py
@@ -1,28 +1,20 @@
 import qt
 
-from CARTLib.utils.config import UserConfig
+from CARTLib.utils.config import DictBackedConfig, UserConfig
 
 
-class MultiContrastSegmentationConfig:
+class MultiContrastSegmentationConfig(DictBackedConfig):
     """
     Configuration manager for the MultiContrast task
     """
-    def __init__(self, backing_dict: dict, parent_config: UserConfig):
-        self._backing_dict = backing_dict
-        self.has_changed = False
+    CONFIG_KEY = "multi_contrast_segmentation"
 
-        self.parent_config = parent_config
+    def __init__(self, parent_config: UserConfig):
+        super().__init__(parent_config=parent_config)
 
-    @property
-    def backing_dict(self) -> dict:
-        return self._backing_dict.copy()
-
-    @backing_dict.setter
-    def backing_dict(self, new_dict: dict):
-        self._backing_dict.clear()
-        for k, v in new_dict.values():
-            self._backing_dict[k] = v
-        self.has_changed = False
+    @classmethod
+    def default_config_label(cls) -> str:
+        return cls.CONFIG_KEY
 
     ## Configuration Options ##
     SHOW_ON_LOAD_KEY = "show_on_load"
@@ -42,9 +34,6 @@ class MultiContrastSegmentationConfig:
         prompt = MultiContrastSegmentationConfigGUI(bound_config=self)
         # Show it, blocking other interactions until its resolved
         prompt.exec()
-
-    def save_to_file(self):
-        self.parent_config.save_to_file()
 
 
 class MultiContrastSegmentationConfigGUI(qt.QDialog):
@@ -107,7 +96,7 @@ class MultiContrastSegmentationConfigGUI(qt.QDialog):
         # Match it to our corresponding function
         # TODO: Replace this with a `match` statement when porting to Slicer 5.9
         if button_role == qt.QDialogButtonBox.AcceptRole:
-            self.bound_config.save_to_file()
+            self.bound_config.save()
             self.accept()
         elif button_role == qt.QDialogButtonBox.RejectRole:
             self.preCloseCheck()
@@ -136,7 +125,7 @@ class MultiContrastSegmentationConfigGUI(qt.QDialog):
             )
             # Save to file only if the user confirms it
             if reply == qt.QMessageBox.Yes:
-                self.bound_config.save_to_file()
+                self.bound_config.save()
                 return True
             else:
                 self.bound_config.backing_dict = self._reserve_state

--- a/CART/CARTLib/examples/MultiContrastSegmentation/MultiContrastSegmentationConfig.py
+++ b/CART/CARTLib/examples/MultiContrastSegmentation/MultiContrastSegmentationConfig.py
@@ -21,7 +21,7 @@ class MultiContrastSegmentationConfig(DictBackedConfig):
 
     @property
     def show_on_load(self) -> bool:
-        return self._backing_dict.get(self.SHOW_ON_LOAD_KEY, False)
+        return self._backing_dict.get(self.SHOW_ON_LOAD_KEY, True)
 
     @show_on_load.setter
     def show_on_load(self, new_state: bool):

--- a/CART/CARTLib/examples/MultiContrastSegmentation/MultiContrastSegmentationConfig.py
+++ b/CART/CARTLib/examples/MultiContrastSegmentation/MultiContrastSegmentationConfig.py
@@ -1,0 +1,31 @@
+from CARTLib.utils.config import UserConfig
+
+
+class MultiContrastSegmentationConfig:
+    """
+    Configuration manager for the MultiContrast task
+    """
+    def __init__(self, backing_dict: dict, parent_config: UserConfig):
+        self._backing_dict = backing_dict
+        self.parent_config = parent_config
+
+    @property
+    def backing_dict(self) -> dict:
+        return self._backing_dict.copy()
+
+    @backing_dict.setter
+    def backing_dict(self, new_dict: dict):
+        self._backing_dict.clear()
+        for k, v in new_dict.values():
+            self._backing_dict[k] = v
+
+    ## Configuration Options ##
+    SHOW_ON_LOAD_KEY = "show_on_load"
+
+    @property
+    def show_on_load(self) -> bool:
+        return self._backing_dict.get(self.SHOW_ON_LOAD_KEY, False)
+
+    @show_on_load.setter
+    def show_on_load(self, new_state: bool):
+        self._backing_dict[self.SHOW_ON_LOAD_KEY] = new_state

--- a/CART/CARTLib/examples/MultiContrastSegmentation/MultiContrastSegmentationConfig.py
+++ b/CART/CARTLib/examples/MultiContrastSegmentation/MultiContrastSegmentationConfig.py
@@ -1,3 +1,5 @@
+import qt
+
 from CARTLib.utils.config import UserConfig
 
 
@@ -7,6 +9,8 @@ class MultiContrastSegmentationConfig:
     """
     def __init__(self, backing_dict: dict, parent_config: UserConfig):
         self._backing_dict = backing_dict
+        self.has_changed = False
+
         self.parent_config = parent_config
 
     @property
@@ -18,6 +22,7 @@ class MultiContrastSegmentationConfig:
         self._backing_dict.clear()
         for k, v in new_dict.values():
             self._backing_dict[k] = v
+        self.has_changed = False
 
     ## Configuration Options ##
     SHOW_ON_LOAD_KEY = "show_on_load"
@@ -29,3 +34,120 @@ class MultiContrastSegmentationConfig:
     @show_on_load.setter
     def show_on_load(self, new_state: bool):
         self._backing_dict[self.SHOW_ON_LOAD_KEY] = new_state
+        self.has_changed = True
+
+    ## Utils ##
+    def show_gui(self):
+        # Build the Config prompt
+        prompt = MultiContrastSegmentationConfigGUI(bound_config=self)
+        # Show it, blocking other interactions until its resolved
+        prompt.exec()
+
+    def save_to_file(self):
+        self.parent_config.save_to_file()
+
+
+class MultiContrastSegmentationConfigGUI(qt.QDialog):
+    """
+    Configuration dialog which allows the user to configure this task.
+    """
+    def __init__(self, bound_config: MultiContrastSegmentationConfig):
+        # Initialize the QDialog base itself
+        super().__init__()
+
+        # Track the config we are abound too
+        self.bound_config: MultiContrastSegmentationConfig = bound_config
+
+        # Button box to reference later
+        self.buttonBox: qt.QDialogButtonBox = None
+
+        # Build the UI elements for this dialog
+        self.build_ui()
+
+    def build_ui(self):
+        # General window properties
+        self.setWindowTitle("CART Configuration")
+
+        # Create a form layout to hold everything in
+        layout = qt.QFormLayout()
+        self.setLayout(layout)
+
+        # Add a checkbox for "show_on_load"
+        loadOnShowCheckBox = qt.QCheckBox()
+        loadOnShowLabel = qt.QLabel("Show Segmentation on Load:")
+        loadOnShowLabel.setToolTip(
+            "If checked, the primary segmentation (if present) will be shown immediately."
+        )
+
+        # Ensure it is synchronized with the configuration settings
+        loadOnShowCheckBox.setChecked(self.bound_config.show_on_load)
+        def onLoadShowCheckBoxChanged(new_val: bool):
+            self.bound_config.show_on_load = new_val
+        loadOnShowCheckBox.stateChanged.connect(onLoadShowCheckBoxChanged)
+
+        # Add it to our layout
+        layout.addRow(loadOnShowLabel, loadOnShowCheckBox)
+
+        # Add our button array to the bottom of the GUI
+        self.buttonBox = self.addButtons()
+        layout.addRow(self.buttonBox)
+
+    def addButtons(self) -> qt.QDialogButtonBox:
+        buttonBox = qt.QDialogButtonBox()
+        buttonBox.setStandardButtons(
+            qt.QDialogButtonBox.Reset | qt.QDialogButtonBox.Cancel | qt.QDialogButtonBox.Ok
+        )
+        buttonBox.clicked.connect(self.onButtonPressed)
+        return buttonBox
+
+    def onButtonPressed(self, button: qt.QPushButton):
+        # Get the role of the button
+        button_role = self.buttonBox.buttonRole(button)
+
+        # Match it to our corresponding function
+        # TODO: Replace this with a `match` statement when porting to Slicer 5.9
+        if button_role == qt.QDialogButtonBox.AcceptRole:
+            self.bound_config.save_to_file()
+            self.accept()
+        elif button_role == qt.QDialogButtonBox.RejectRole:
+            self.preCloseCheck()
+            self.reject()
+        elif button_role == qt.QDialogButtonBox.ResetRole:
+            self.bound_config.backing_dict = self._reserve_state
+            self.reject()
+        else:
+            raise ValueError("Pressed a button with an invalid role somehow...")
+
+    ## On-close calls ##
+    def preCloseCheck(self):
+        """
+        Before the prompt closes, check to confirm no changes were made
+        that the user might want to save beforehand!
+
+        :return: Whether the save request was accepted.
+        """
+        # Only run checks if the config has changed at all
+        if self.bound_config.has_changed:
+            reply = qt.QMessageBox.question(
+                self,
+                "Unsaved Changes",
+                "You have not saved your changes; would you like to now?",
+                qt.QMessageBox.Yes, qt.QMessageBox.No
+            )
+            # Save to file only if the user confirms it
+            if reply == qt.QMessageBox.Yes:
+                self.bound_config.save_to_file()
+                return True
+            else:
+                self.bound_config.backing_dict = self._reserve_state
+                return False
+        # Otherwise, just pass successfully
+        return True
+
+    def closeEvent(self, event):
+        """
+        Intercepts when the user closes the window outside by clicking the 'x'
+        in the top right; ensures any modifications don't get discarded by mistake.
+        """
+        self.preCloseCheck()
+        event.accept()

--- a/CART/CARTLib/examples/MultiContrastSegmentation/MultiContrastSegmentationConfig.py
+++ b/CART/CARTLib/examples/MultiContrastSegmentation/MultiContrastSegmentationConfig.py
@@ -1,6 +1,6 @@
 import qt
 
-from CARTLib.utils.config import DictBackedConfig, UserConfig
+from CARTLib.utils.config import DictBackedConfig, ConfigDialog, UserConfig
 
 
 class MultiContrastSegmentationConfig(DictBackedConfig):
@@ -36,31 +36,20 @@ class MultiContrastSegmentationConfig(DictBackedConfig):
         prompt.exec()
 
 
-class MultiContrastSegmentationConfigGUI(qt.QDialog):
+class MultiContrastSegmentationConfigGUI(
+    ConfigDialog[MultiContrastSegmentationConfig]
+):
     """
     Configuration dialog which allows the user to configure this task.
     """
-    def __init__(self, bound_config: MultiContrastSegmentationConfig):
-        # Initialize the QDialog base itself
-        super().__init__()
-
-        # Track the config we are abound too
-        self.bound_config: MultiContrastSegmentationConfig = bound_config
-
-        # Button box to reference later
-        self.buttonBox: qt.QDialogButtonBox = None
-
-        # Build the UI elements for this dialog
-        self.build_ui()
-
-    def build_ui(self):
+    def buildGUI(self, layout: qt.QFormLayout):
         # General window properties
         self.setWindowTitle("CART Configuration")
 
-        # Create a form layout to hold everything in
-        layout = qt.QFormLayout()
-        self.setLayout(layout)
+        # Add the load-on-show widget
+        self._buildLoadOnShowCheckBox(layout)
 
+    def _buildLoadOnShowCheckBox(self, layout):
         # Add a checkbox for "show_on_load"
         loadOnShowCheckBox = qt.QCheckBox()
         loadOnShowLabel = qt.QLabel("Show Segmentation on Load:")
@@ -69,7 +58,6 @@ class MultiContrastSegmentationConfigGUI(qt.QDialog):
         )
 
         # Ensure it is synchronized with the configuration settings
-        loadOnShowCheckBox.setChecked(self.bound_config.show_on_load)
         def onLoadShowCheckBoxChanged(new_val: bool):
             self.bound_config.show_on_load = new_val
         loadOnShowCheckBox.stateChanged.connect(onLoadShowCheckBoxChanged)
@@ -77,66 +65,9 @@ class MultiContrastSegmentationConfigGUI(qt.QDialog):
         # Add it to our layout
         layout.addRow(loadOnShowLabel, loadOnShowCheckBox)
 
-        # Add our button array to the bottom of the GUI
-        self.buttonBox = self.addButtons()
-        layout.addRow(self.buttonBox)
+        # Track it for later
+        self.loadOnShowCheckBox = loadOnShowCheckBox
 
-    def addButtons(self) -> qt.QDialogButtonBox:
-        buttonBox = qt.QDialogButtonBox()
-        buttonBox.setStandardButtons(
-            qt.QDialogButtonBox.Reset | qt.QDialogButtonBox.Cancel | qt.QDialogButtonBox.Ok
-        )
-        buttonBox.clicked.connect(self.onButtonPressed)
-        return buttonBox
-
-    def onButtonPressed(self, button: qt.QPushButton):
-        # Get the role of the button
-        button_role = self.buttonBox.buttonRole(button)
-
-        # Match it to our corresponding function
-        # TODO: Replace this with a `match` statement when porting to Slicer 5.9
-        if button_role == qt.QDialogButtonBox.AcceptRole:
-            self.bound_config.save()
-            self.accept()
-        elif button_role == qt.QDialogButtonBox.RejectRole:
-            self.preCloseCheck()
-            self.reject()
-        elif button_role == qt.QDialogButtonBox.ResetRole:
-            self.bound_config.backing_dict = self._reserve_state
-            self.reject()
-        else:
-            raise ValueError("Pressed a button with an invalid role somehow...")
-
-    ## On-close calls ##
-    def preCloseCheck(self):
-        """
-        Before the prompt closes, check to confirm no changes were made
-        that the user might want to save beforehand!
-
-        :return: Whether the save request was accepted.
-        """
-        # Only run checks if the config has changed at all
-        if self.bound_config.has_changed:
-            reply = qt.QMessageBox.question(
-                self,
-                "Unsaved Changes",
-                "You have not saved your changes; would you like to now?",
-                qt.QMessageBox.Yes, qt.QMessageBox.No
-            )
-            # Save to file only if the user confirms it
-            if reply == qt.QMessageBox.Yes:
-                self.bound_config.save()
-                return True
-            else:
-                self.bound_config.backing_dict = self._reserve_state
-                return False
-        # Otherwise, just pass successfully
-        return True
-
-    def closeEvent(self, event):
-        """
-        Intercepts when the user closes the window outside by clicking the 'x'
-        in the top right; ensures any modifications don't get discarded by mistake.
-        """
-        self.preCloseCheck()
-        event.accept()
+    def sync(self):
+        # Load-on-show checkbox synchronization
+        self.loadOnShowCheckBox.setChecked(self.bound_config.show_on_load)

--- a/CART/CARTLib/examples/MultiContrastSegmentation/MultiContrastSegmentationEvaluationDataUnit.py
+++ b/CART/CARTLib/examples/MultiContrastSegmentation/MultiContrastSegmentationEvaluationDataUnit.py
@@ -300,3 +300,12 @@ class MultiContrastSegmentationEvaluationDataUnit(DataUnitBase):
         if self.subject_id is not None:
             self.hierarchy_node.SetItemExpanded(self.subject_id, new_state)
             self.hierarchy_node.SetItemDisplayVisibility(self.subject_id, new_state)
+
+    def set_primary_segments_visible(self, new_state: bool) -> None:
+        """
+        Sets the visibility of all child segments for the primary segmentation
+        :param new_state: Whether they segment should be visible or not
+        """
+        display_node = self.primary_segmentation_node.GetDisplayNode()
+
+        display_node.SetAllSegmentsVisibility(new_state)

--- a/CART/CARTLib/examples/MultiContrastSegmentation/MultiContrastSegmentationEvaluationTask.py
+++ b/CART/CARTLib/examples/MultiContrastSegmentation/MultiContrastSegmentationEvaluationTask.py
@@ -444,7 +444,6 @@ class MultiContrastSegmentationEvaluationTask(
         # Configuration
         self.config: MultiContrastSegmentationConfig = (
             MultiContrastSegmentationConfig(
-                backing_dict=self.user.get_sub_config(self.CONFIG_ID),
                 parent_config=self.user
             )
         )

--- a/CART/CARTLib/examples/MultiContrastSegmentation/MultiContrastSegmentationEvaluationTask.py
+++ b/CART/CARTLib/examples/MultiContrastSegmentation/MultiContrastSegmentationEvaluationTask.py
@@ -14,6 +14,7 @@ from .MultiContrastSegmentationEvaluationDataUnit import (
 from CARTLib.core.TaskBaseClass import TaskBaseClass, DataUnitFactory
 from CARTLib.utils.widgets import CARTSegmentationEditorWidget
 from CARTLib.utils.layout import Orientation
+from CARTLib.utils.config import UserConfig
 
 
 class MultiContrastSegmentationEvaluationGUI:
@@ -272,8 +273,10 @@ class MultiContrastSegmentationEvaluationGUI:
 
         # Set default filename if none exists
         if not self.csvLogEdit.currentPath.strip():
-            # Generate default filename based on user and current date
-            default_name = f"segmentation_review_log_{self.bound_task.user}_{datetime.now().strftime('%Y%m%d')}.csv"
+            # Generate default filename based on username and current date
+            username = self.bound_task.username
+            current_datetime = datetime.now().strftime('%Y%m%d')
+            default_name = f"segmentation_review_log_{username}_{current_datetime}.csv"
             dialog.selectFile(default_name)
         else:
             # Use existing path as starting point
@@ -409,7 +412,7 @@ class MultiContrastSegmentationEvaluationGUI:
 class MultiContrastSegmentationEvaluationTask(
     TaskBaseClass[MultiContrastSegmentationEvaluationDataUnit]
 ):
-    def __init__(self, user: str):
+    def __init__(self, user: UserConfig):
         super().__init__(user)
         self.gui: Optional[MultiContrastSegmentationEvaluationGUI] = None
         self.output_mode: OutputMode = OutputMode.PARALLEL_DIRECTORY

--- a/CART/CARTLib/examples/MultiContrastSegmentation/MultiContrastSegmentationEvaluationTask.py
+++ b/CART/CARTLib/examples/MultiContrastSegmentation/MultiContrastSegmentationEvaluationTask.py
@@ -36,6 +36,9 @@ class MultiContrastSegmentationEvaluationGUI:
         # Initialize the layout we'll insert everything into
         formLayout = qt.QFormLayout()
 
+        # 1). Configuration button
+        self._addConfigButton(formLayout)
+
         # 2) Orientation buttons
         self._addOrientationButtons(formLayout)
 
@@ -50,6 +53,17 @@ class MultiContrastSegmentationEvaluationGUI:
         self.promptSelectOutputMode()
 
         return formLayout
+
+    def _addConfigButton(self, layout: qt.QFormLayout):
+        # A button to open the Configuration dialog, which changes how CART operates
+        configButton = qt.QPushButton(_("Configure"))
+        configButton.toolTip = _("Change how CART is configured to iterate through your data.")
+
+        # Clicking the config button shows the Config prompt
+        configButton.clicked.connect(self.bound_task.config.show_gui)
+
+        # Add it to our layout
+        layout.addRow(configButton)
 
     def _addOrientationButtons(self, layout: qt.QFormLayout) -> None:
         """

--- a/CART/CARTLib/examples/MultiContrastSegmentation/MultiContrastSegmentationEvaluationTask.py
+++ b/CART/CARTLib/examples/MultiContrastSegmentation/MultiContrastSegmentationEvaluationTask.py
@@ -11,6 +11,7 @@ from .MultiContrastOutputManager import OutputMode, MultiContrastOutputManager
 from .MultiContrastSegmentationEvaluationDataUnit import (
     MultiContrastSegmentationEvaluationDataUnit,
 )
+from .MultiContrastSegmentationConfig import MultiContrastSegmentationConfig
 from CARTLib.core.TaskBaseClass import TaskBaseClass, DataUnitFactory
 from CARTLib.utils.widgets import CARTSegmentationEditorWidget
 from CARTLib.utils.layout import Orientation
@@ -412,14 +413,27 @@ class MultiContrastSegmentationEvaluationGUI:
 class MultiContrastSegmentationEvaluationTask(
     TaskBaseClass[MultiContrastSegmentationEvaluationDataUnit]
 ):
+
+    CONFIG_ID = "multi_contrast_segmentation"
+
     def __init__(self, user: UserConfig):
         super().__init__(user)
+
+        # Local Attributes
         self.gui: Optional[MultiContrastSegmentationEvaluationGUI] = None
         self.output_mode: OutputMode = OutputMode.PARALLEL_DIRECTORY
         self.output_dir: Optional[Path] = None
         self.output_manager: Optional[MultiContrastOutputManager] = None
         self.data_unit: Optional[MultiContrastSegmentationEvaluationDataUnit] = None
         self.csv_log_path: Optional[Path] = None  # Optional custom CSV log path
+
+        # Configuration
+        self.config: MultiContrastSegmentationConfig = (
+            MultiContrastSegmentationConfig(
+                backing_dict=self.user.get_sub_config(self.CONFIG_ID),
+                parent_config=self.user
+            )
+        )
 
     def setup(self, container: qt.QWidget) -> None:
         print(f"Running {self.__class__.__name__} setup!")
@@ -454,6 +468,12 @@ class MultiContrastSegmentationEvaluationTask(
             foreground=data_unit.primary_segmentation_node,
             fit=True,
         )
+        # Hide the segmentation node if requested by the user's config
+        if not self.config.show_on_load:
+            # TODO
+            print("=" * 100)
+            print("Hiding initial segmentation")
+            print("=" * 100)
         # If we have GUI, update it as well
         if self.gui:
             self.gui.update(data_unit)

--- a/CART/CARTLib/examples/MultiContrastSegmentation/MultiContrastSegmentationEvaluationTask.py
+++ b/CART/CARTLib/examples/MultiContrastSegmentation/MultiContrastSegmentationEvaluationTask.py
@@ -428,8 +428,6 @@ class MultiContrastSegmentationEvaluationTask(
     TaskBaseClass[MultiContrastSegmentationEvaluationDataUnit]
 ):
 
-    CONFIG_ID = "multi_contrast_segmentation"
-
     def __init__(self, user: UserConfig):
         super().__init__(user)
 

--- a/CART/CARTLib/examples/MultiContrastSegmentation/MultiContrastSegmentationEvaluationTask.py
+++ b/CART/CARTLib/examples/MultiContrastSegmentation/MultiContrastSegmentationEvaluationTask.py
@@ -480,11 +480,9 @@ class MultiContrastSegmentationEvaluationTask(
             fit=True,
         )
         # Hide the segmentation node if requested by the user's config
-        if not self.config.show_on_load:
-            # TODO
-            print("=" * 100)
-            print("Hiding initial segmentation")
-            print("=" * 100)
+        self.data_unit.set_primary_segments_visible(
+            self.config.show_on_load
+        )
         # If we have GUI, update it as well
         if self.gui:
             self.gui.update(data_unit)

--- a/CART/CARTLib/examples/RegistrationReview/RegistrationReviewTask.py
+++ b/CART/CARTLib/examples/RegistrationReview/RegistrationReviewTask.py
@@ -509,14 +509,14 @@ class RegistrationReviewTask(TaskBaseClass[RegistrationReviewDataUnit]):
             # Prepare the data to save
             review_data = {
                 self.UID_KEY: self.data_unit.uid,
-                self.USER_KEY: self.user,
+                self.USER_KEY: self.username,
                 "timestamp": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
                 self.STATUS_KEY: self.REVIEW_COMPLETE,
                 "registration_classification": self.gui.selectedClassification,
             }
 
             # Replace/add the entry to our CSV log
-            self.csv_log[(self.data_unit.uid, self.user)] = review_data
+            self.csv_log[(self.data_unit.uid, self.username)] = review_data
 
             # Write the updated data back to our CSV log file
             with open(self.csv_log_path, "w", newline="") as csvfile:
@@ -543,7 +543,7 @@ class RegistrationReviewTask(TaskBaseClass[RegistrationReviewDataUnit]):
             with open(self.csv_log_path, newline="") as csvfile:
                 reader = csv.DictReader(csvfile)
                 for row in reader:
-                    if row.get("uid") == uid and row.get("user") == self.user:
+                    if row.get("uid") == uid and row.get(self.USER_KEY) == self.username:
                         return row
             return None
         except Exception as e:
@@ -621,7 +621,7 @@ class RegistrationReviewTask(TaskBaseClass[RegistrationReviewDataUnit]):
             return False
 
         # Check if we have an entry for this user and UID
-        case_entry = self.csv_log.get((self.data_unit.uid, self.user), None)
+        case_entry = self.csv_log.get((self.data_unit.uid, self.username), None)
         # If not, the task hasn't been completed
         if not case_entry:
             return False

--- a/CART/CARTLib/examples/SegmentationEvaluation/SegmentationEvaluationTask.py
+++ b/CART/CARTLib/examples/SegmentationEvaluation/SegmentationEvaluationTask.py
@@ -354,7 +354,7 @@ class SegmentationEvaluationTask(TaskBaseClass[SegmentationEvaluationDataUnit]):
         print(f"Output path set to: {self.output_dir}")
 
         # Create a new output manager with this directory
-        self.output_manager = _OutputManager(self.output_dir, self.user)
+        self.output_manager = _OutputManager(self.output_dir, self.username)
 
         return None
 

--- a/CART/CARTLib/utils/config.py
+++ b/CART/CARTLib/utils/config.py
@@ -39,11 +39,11 @@ class ConfigGUI(qt.QDialog):
         )
 
         # Ensure it is synchronized with the configuration settings
-        iterSaveCheck.setChecked(self.bound_config.autosave)
-        def setAutosave(new_state: bool):
-            self.bound_config.autosave = bool(new_state)
+        iterSaveCheck.setChecked(self.bound_config.save_on_iter)
+        def setSaveOnIter(new_state: bool):
+            self.bound_config.save_on_iter = bool(new_state)
         iterSaveCheck.stateChanged.connect(
-            lambda x: setAutosave(x)
+            lambda x: setSaveOnIter(x)
         )
         layout.addRow(iterSaveLabel, iterSaveCheck)
 
@@ -170,15 +170,17 @@ class Config:
         self._backing_dict["last_used_task"] = new_task
 
     ## Autosaving Management ##
-    @property
-    def autosave(self) -> bool:
-        return self._get_or_default("autosave", True)
+    SAVE_ON_ITER_KEY = "save_on_iter"
 
-    @autosave.setter
-    def autosave(self, new_val: bool):
+    @property
+    def save_on_iter(self) -> bool:
+        return self._get_or_default(self.SAVE_ON_ITER_KEY, True)
+
+    @save_on_iter.setter
+    def save_on_iter(self, new_val: bool):
         # Validate that the value is a boolean, to avoid weird jank later
-        assert isinstance(new_val, bool), "Autosave must be a boolean value."
-        self._backing_dict["autosave"] = new_val
+        assert isinstance(new_val, bool), f"'{self.SAVE_ON_ITER_KEY}' must be a boolean value."
+        self._backing_dict[self.SAVE_ON_ITER_KEY] = new_val
         self._has_changed = True
 
     ## Utils ##

--- a/CART/CARTLib/utils/config.py
+++ b/CART/CARTLib/utils/config.py
@@ -114,6 +114,7 @@ class ConfigGUI(qt.QDialog):
         event.accept()
 
 
+## Backing Config Managers ##
 class UserConfig:
     """
     Configuration manager for a CART user profile.
@@ -121,13 +122,20 @@ class UserConfig:
     Tracks the user's settings, allowing for them to be
     swapped on the fly.
     """
-    def __init__(self, config_dict: dict, cart_config: "CARTConfig"):
+    def __init__(self, username: str, config_dict: dict, cart_config: "CARTConfig"):
+        # The username for this profile
+        self._username = username
+
         # Cross-reference attributes
         self._backing_dict = config_dict
         self._cart_config = cart_config
 
         # Track whether something has changed, so other processes can reference it
         self._has_changed = False
+
+    @property
+    def username(self):
+        return self._username
 
     @property
     def has_changed(self):
@@ -270,12 +278,12 @@ class CARTConfig:
         self.profiles[username] = new_profile
 
         # Return the result, wrapped in our UserConfig
-        return UserConfig(new_profile, self)
+        return UserConfig(username, new_profile, self)
 
     def get_user_config(self, username: str):
         user_dict = self.profiles.get(username, {})
         if user_dict:
-            return UserConfig(user_dict, self)
+            return UserConfig(username, user_dict, self)
         else:
             return None
 

--- a/CART/CARTLib/utils/config.py
+++ b/CART/CARTLib/utils/config.py
@@ -1,9 +1,52 @@
 import json
 from pathlib import Path
 
+import qt
+
 # The location of the default config used by a fresh installation of CART.
 #  DO NOT TOUCH IT UNLESS YOU KNOW WHAT YOU'RE DOING.
 DEFAULT_FILE = Path(__file__).parent / "default_config.json"
+
+
+class ConfigGUI(qt.QDialog):
+    """
+    Configuration dialog which allows the user to configure CART.
+    """
+
+    def __init__(self, bound_config: "Config"):
+        # Initialize the QDialog base itself
+        super().__init__()
+
+        # Track the bound configuration to ourselves
+        self.bound_config = bound_config
+
+        # Built the GUI contents
+        self.build_ui()
+
+
+    def build_ui(self):
+        # General window properties
+        self.setWindowTitle("CART Configuration")
+
+        # Create a form layout to hold everything in
+        layout = qt.QFormLayout()
+        self.setLayout(layout)
+
+        # Add a checkbox for the state of autosaving
+        iterSaveCheck = qt.QCheckBox()
+        iterSaveLabel = qt.QLabel("Save on Iteration:")
+        iterSaveLabel.setToolTip(
+            "If checked, the Task will try to save when you change cases automatically."
+        )
+
+        # Ensure it is synchronized with the configuration settings
+        iterSaveCheck.setCheckState(self.bound_config.autosave)
+        def setAutosave(new_state: bool):
+            self.bound_config.autosave = bool(new_state)
+        iterSaveCheck.stateChanged.connect(
+            lambda x: setAutosave(x)
+        )
+        layout.addRow(iterSaveLabel, iterSaveCheck)
 
 
 class Config:
@@ -139,6 +182,12 @@ class Config:
             self._has_changed = True
 
         return val
+
+    def show_gui(self):
+        # Build the Config prompt
+        prompt = ConfigGUI(bound_config=self)
+        # Show it, blocking other interactions until its resolved
+        prompt.exec()
 
 
 # The location of the config file for this installation of CART.

--- a/CART/CARTLib/utils/config.py
+++ b/CART/CARTLib/utils/config.py
@@ -82,7 +82,7 @@ class NewUserDialog(qt.QDialog):
         else:
             raise ValueError("Pressed a button with an invalid role somehow...")
 
-    ## Utils
+    ## Access Management ##s
     @property
     def username(self) -> str:
         return self.usernameEdit.text
@@ -381,9 +381,9 @@ class CARTConfig:
         # Return the result, wrapped in our UserConfig
         return UserConfig(username, new_profile, self)
 
-    def get_user_config(self, username: str):
-        user_dict = self.profiles.get(username, {})
-        if user_dict:
+    def get_user_config(self, username: str) -> Optional[UserConfig]:
+        user_dict = self.profiles.get(username, None)
+        if user_dict is not None:
             return UserConfig(username, user_dict, self)
         else:
             return None

--- a/CART/CARTLib/utils/config.py
+++ b/CART/CARTLib/utils/config.py
@@ -69,7 +69,7 @@ class UserConfig:
     swapped on the fly.
     """
 
-    def __init__(self, config_dict: dict[str, dict], cart_config: "CARTConfig"):
+    def __init__(self, config_dict: dict, cart_config: "CARTConfig"):
         # Cross-reference attributes
         self._backing_dict = config_dict
         self._cart_config = cart_config

--- a/CART/CARTLib/utils/config.py
+++ b/CART/CARTLib/utils/config.py
@@ -120,6 +120,7 @@ class NewUserDialog(qt.QDialog):
                 self.reference_profile
             )
 
+
 class ConfigGUI(qt.QDialog):
     """
     Configuration dialog which allows the user to configure CART.

--- a/CART/CARTLib/utils/config.py
+++ b/CART/CARTLib/utils/config.py
@@ -96,8 +96,22 @@ class NewUserDialog(qt.QDialog):
         self.buttonBox = self.addButtons()
         layout.addRow(self.buttonBox)
 
-        # Connect everything together
-        # TODO
+        # Only enable the "confirm" button when a valid username is present
+        okButton = self.buttonBox.button(qt.QDialogButtonBox.Ok)
+        def syncOkButtonState(username: str):
+            stripped_name = username.strip()
+            if not stripped_name:
+                okButton.setEnabled(False)
+                okButton.setToolTip("Users must have a non-blank username")
+            elif stripped_name in self.master_config.profiles.keys():
+                okButton.setEnabled(False)
+                okButton.setToolTip("The provided username already exists!")
+            else:
+                okButton.setEnabled(True)
+                okButton.setToolTip("")
+        self.usernameEdit.textChanged.connect(syncOkButtonState)
+        # Sync the OK button's state immediately
+        syncOkButtonState(usernameEdit.text)
 
     def onButtonPressed(self, button: qt.QPushButton):
         # Get the role of the button

--- a/CART/CARTLib/utils/config.py
+++ b/CART/CARTLib/utils/config.py
@@ -405,6 +405,22 @@ class UserConfig:
         self._backing_dict[self.SAVE_ON_ITER_KEY] = new_val
         self._has_changed = True
 
+    ## Sub-Configurations ##
+    SUB_CONFIGS_KEY = "sub_config"
+
+    @property
+    def sub_configs(self) -> dict:
+        return self._get_or_default(self.SUB_CONFIGS_KEY, {})
+
+    def get_sub_config(self, key: str):
+        sub_entry = self.sub_configs.get(key, False)
+        if not sub_entry:
+            new_entry = {}
+            self.sub_configs[key] = new_entry
+            return new_entry
+        else:
+            return sub_entry
+
     ## Utils ##
     def _get_or_default(self, key, default):
         # Try to get the specified value

--- a/CART/CARTLib/utils/config.py
+++ b/CART/CARTLib/utils/config.py
@@ -235,6 +235,9 @@ class UserConfig:
     Tracks the user's settings, allowing for them to be
     swapped on the fly.
     """
+
+    DEFAULT_ROLE = "N/A"
+
     def __init__(self, username: str, config_dict: dict, cart_config: "CARTConfig"):
         # The username for this profile
         self._username = username
@@ -307,6 +310,13 @@ class UserConfig:
     def last_used_task(self, new_task: str):
         self._backing_dict[self.LAST_USED_TASK_KEY] = new_task
 
+    ## User Role ##
+    ROLE_KEY = "role"
+
+    @property
+    def role(self) -> str:
+        return self._get_or_default(self.ROLE_KEY, self.DEFAULT_ROLE)
+
     ## Autosaving Management ##
     SAVE_ON_ITER_KEY = "save_on_iter"
 
@@ -366,6 +376,7 @@ class CARTConfig:
 
     ## User Management ##
     PROFILE_KEY = "user_profiles"
+    DEFAULT_ROLES = [UserConfig.DEFAULT_ROLE]
 
     @property
     def profiles(self) -> dict[str, dict]:
@@ -446,6 +457,18 @@ class CARTConfig:
     @last_user.setter
     def last_user(self, new_user: str):
         self._backing_dict[self.LAST_USER_KEY] = new_user
+
+    USER_ROLES_KEY = "user_roles"
+
+    @property
+    def user_roles(self) -> list[str]:
+        return self._get_or_default(self.USER_ROLES_KEY, self.DEFAULT_ROLES)
+
+    def new_user_role(self, new_role: str):
+        if new_role in self.user_roles:
+            raise ValueError(f"Role '{new_role}' already exists!")
+
+        self.user_roles.append(new_role)
 
     ## I/O ##
     def load(self):

--- a/CART/CARTLib/utils/config.py
+++ b/CART/CARTLib/utils/config.py
@@ -12,7 +12,6 @@ class ConfigGUI(qt.QDialog):
     """
     Configuration dialog which allows the user to configure CART.
     """
-
     def __init__(self, bound_config: "UserConfig"):
         # Initialize the QDialog base itself
         super().__init__()
@@ -84,7 +83,6 @@ class UserConfig:
     Tracks the user's settings, allowing for them to be
     swapped on the fly.
     """
-
     def __init__(self, config_dict: dict, cart_config: "CARTConfig"):
         # Cross-reference attributes
         self._backing_dict = config_dict
@@ -96,6 +94,20 @@ class UserConfig:
     @property
     def has_changed(self):
         return self._has_changed
+
+    @property
+    def backing_dict(self):
+        # KO: We really don't want direct access to the dict itself,
+        #  so we return a copy instead
+        return self._backing_dict.copy()
+
+    @backing_dict.setter
+    def backing_dict(self, new_dict: dict):
+        # KO: we can't just assign, otherwise it would
+        #  de-sync with the global config
+        self._backing_dict.clear()
+        for k, v in new_dict.items():
+            self._backing_dict[k] = v
 
     ## Last Used Settings ##
     LAST_USED_COHORT_KEY = "last_used_cohort_file"
@@ -166,10 +178,10 @@ class UserConfig:
         prompt = ConfigGUI(bound_config=self)
         # Show it, blocking other interactions until its resolved
         prompt.exec()
-        
+
     def save_to_file(self):
         # Only do the (relatively) expensive I/O when we have changes
-        if self._has_changed:
+        if self.has_changed:
             self._cart_config.save()
 
 

--- a/CART/CARTLib/utils/config.py
+++ b/CART/CARTLib/utils/config.py
@@ -39,7 +39,7 @@ class ConfigGUI(qt.QDialog):
         )
 
         # Ensure it is synchronized with the configuration settings
-        iterSaveCheck.setCheckState(self.bound_config.autosave)
+        iterSaveCheck.setChecked(self.bound_config.autosave)
         def setAutosave(new_state: bool):
             self.bound_config.autosave = bool(new_state)
         iterSaveCheck.stateChanged.connect(

--- a/CART/CARTLib/utils/config.py
+++ b/CART/CARTLib/utils/config.py
@@ -20,6 +20,9 @@ class ConfigGUI(qt.QDialog):
         # Track the bound configuration to ourselves
         self.bound_config = bound_config
 
+        # Track the button box so we can react to them being pressed
+        self.buttonBox: qt.QDialogButtonBox = None
+
         # Built the GUI contents
         self.build_ui()
 
@@ -42,23 +45,36 @@ class ConfigGUI(qt.QDialog):
         iterSaveCheck.setChecked(self.bound_config.save_on_iter)
         def setSaveOnIter(new_state: bool):
             self.bound_config.save_on_iter = bool(new_state)
-        iterSaveCheck.stateChanged.connect(
-            lambda x: setSaveOnIter(x)
-        )
+        iterSaveCheck.stateChanged.connect(setSaveOnIter)
+
+        # Add it to our layout
         layout.addRow(iterSaveLabel, iterSaveCheck)
 
-        buttonBox = self.addButtons()
-        layout.addRow(buttonBox)
+        # Add our button array to the bottom of the GUI
+        self.buttonBox = self.addButtons()
+        layout.addRow(self.buttonBox)
 
     def addButtons(self):
         buttonBox = qt.QDialogButtonBox()
         buttonBox.setStandardButtons(
             qt.QDialogButtonBox.Reset | qt.QDialogButtonBox.Cancel | qt.QDialogButtonBox.Ok
         )
-        buttonBox.clicked.connect(
-            lambda b: print(buttonBox.buttonRole(b))
-        )
+        buttonBox.clicked.connect(self.onButtonPressed)
         return buttonBox
+
+    def onButtonPressed(self, button: qt.QPushButton):
+        # Get the role of the button
+        button_role = self.buttonBox.buttonRole(button)
+        # Match it to our corresponding function
+        # TODO: Replace this with a `match` statement when porting to Slicer 5.9
+        if button_role == qt.QDialogButtonBox.AcceptRole:
+            print("Accepted!")
+        elif button_role == qt.QDialogButtonBox.RejectRole:
+            print("Rejected...")
+        elif button_role == qt.QDialogButtonBox.ResetRole:
+            print("Reset?")
+        else:
+            raise ValueError("Pressed a button with an invalid role somehow...")
 
 
 class UserConfig:

--- a/CART/CARTLib/utils/config.py
+++ b/CART/CARTLib/utils/config.py
@@ -23,7 +23,6 @@ class ConfigGUI(qt.QDialog):
         # Built the GUI contents
         self.build_ui()
 
-
     def build_ui(self):
         # General window properties
         self.setWindowTitle("CART Configuration")
@@ -47,6 +46,19 @@ class ConfigGUI(qt.QDialog):
             lambda x: setAutosave(x)
         )
         layout.addRow(iterSaveLabel, iterSaveCheck)
+
+        buttonBox = self.addButtons()
+        layout.addRow(buttonBox)
+
+    def addButtons(self):
+        buttonBox = qt.QDialogButtonBox()
+        buttonBox.setStandardButtons(
+            qt.QDialogButtonBox.Reset | qt.QDialogButtonBox.Cancel | qt.QDialogButtonBox.Ok
+        )
+        buttonBox.clicked.connect(
+            lambda b: print(buttonBox.buttonRole(b))
+        )
+        return buttonBox
 
 
 class Config:

--- a/CART/CARTLib/utils/config.py
+++ b/CART/CARTLib/utils/config.py
@@ -183,7 +183,7 @@ class CARTConfig:
         if not stripped_name:
             raise ValueError("Cannot create a user without a username!")
 
-        if stripped_name in config.profiles.keys():
+        if stripped_name in GLOBAL_CONFIG.profiles.keys():
             raise ValueError(f"User with username '{stripped_name}' already exists!")
 
         # If we don't have a reference profile, create a blank profile
@@ -263,4 +263,4 @@ class CARTConfig:
 # The location of the config file for this installation of CART.
 MAIN_CONFIG = Path(__file__).parent.parent.parent / "configuration.json"
 
-config = CARTConfig(MAIN_CONFIG)
+GLOBAL_CONFIG = CARTConfig(MAIN_CONFIG)

--- a/CART/CARTLib/utils/config.py
+++ b/CART/CARTLib/utils/config.py
@@ -27,6 +27,10 @@ class NewUserDialog(qt.QDialog):
         # The text field widget for the username
         self.usernameEdit: qt.QLineEdit = None
 
+        # Toggle box which make the profile a blank slate if checked
+        # (instead of copying the active profile's state, the default)
+        self.blankSlateBox: qt.QCheckBox = None
+
         # Track the button box so we can react to them being pressed
         self.buttonBox: qt.QDialogButtonBox = None
 
@@ -62,6 +66,17 @@ class NewUserDialog(qt.QDialog):
         # Add them to our layout
         layout.addRow(usernameLabel, usernameEdit)
 
+        # Add the blank-state checkbox
+        blankStateBox = qt.QCheckBox()
+        blankStateLabel = qt.QLabel("Reset to Default?")
+        blankStateLabel.setToolTip("""
+            If selected, the new user profile will have no configuration settings, 
+            being a "blank slate". If unchecked, the configuration settings of the 
+            current profile (including the last-used settings) are copied over instead.
+        """)
+        self.blankSlateBox = blankStateBox
+        layout.addRow(blankStateLabel, blankStateBox)
+
         # Add our button array to the bottom of the GUI
         self.buttonBox = self.addButtons()
         layout.addRow(self.buttonBox)
@@ -87,12 +102,23 @@ class NewUserDialog(qt.QDialog):
     def username(self) -> str:
         return self.usernameEdit.text
 
+    @property
+    def shouldBlankState(self) -> bool:
+        return self.blankSlateBox.isChecked()
+
+    ## Utils
     def saveNewProfile(self):
-        self.master_config.new_user_profile(
-            self.username,
-            self.profile_dict,
-            self.reference_profile
-        )
+        if self.shouldBlankState:
+            self.master_config.new_user_profile(
+                self.username,
+                self.profile_dict
+            )
+        else:
+            self.master_config.new_user_profile(
+                self.username,
+                self.profile_dict,
+                self.reference_profile
+            )
 
 class ConfigGUI(qt.QDialog):
     """

--- a/CART/CARTLib/utils/config.py
+++ b/CART/CARTLib/utils/config.py
@@ -47,9 +47,17 @@ class DictBackedConfig(ABC):
 
     @backing_dict.setter
     def backing_dict(self, new_dict: dict):
+        """
+        The backing dictionary for this Config.
+
+        NOTE: The setter for this attribute does NOT change `has_changed` in any
+        way; you should change it to match the context of why you overwrote the
+        backing dict directly (i.e. setting it to "False" when you're resetting to
+        a previous state).
+        """
         # KO: To prevent de-sync with the parent config, replace the contents of
         #  our backing dict with the new dicts contents (instead of replacing
-        #  the dictionary itself
+        #  the dictionary itself)
         self._backing_dict.clear()
         for k, v in new_dict.items():
             self._backing_dict[k] = v
@@ -772,6 +780,7 @@ class UserConfigDialog(ConfigDialog[UserConfig]):
         self.roleComboBox.clear()
         self.roleComboBox.addItems(self.bound_config.valid_roles)
         self.roleComboBox.currentText = self.bound_config.role
+
 
 # The location of the config file for this installation of CART.
 MAIN_CONFIG = Path(__file__).parent.parent.parent / "configuration.json"

--- a/CART/CARTLib/utils/config.py
+++ b/CART/CARTLib/utils/config.py
@@ -78,37 +78,40 @@ class UserConfig:
         self._has_changed = False
 
     ## Last Used Settings ##
+    LAST_USED_COHORT_KEY = "last_used_cohort_file"
+
     @property
     def last_used_cohort_file(self) -> Path:
-        key = "last_used_cohort_file"
-        val = Path(self._backing_dict.get(key, ""))
+        val = Path(self._backing_dict.get(self.LAST_USED_COHORT_KEY, ""))
         return val
 
     @last_used_cohort_file.setter
     def last_used_cohort_file(self, new_path: Path):
-        self._backing_dict["last_used_cohort_file"] = str(new_path)
+        self._backing_dict[self.LAST_USED_COHORT_KEY] = str(new_path)
         self._has_changed = True
+
+    LAST_USED_DATA_KEY = "last_used_data_path"
 
     @property
     def last_used_data_path(self) -> Path:
-        key = "last_used_data_path"
-        val = Path(self._backing_dict.get(key, ""))
+        val = Path(self._backing_dict.get(self.LAST_USED_DATA_KEY, ""))
         return val
 
     @last_used_data_path.setter
     def last_used_data_path(self, new_path: Path):
-        self._backing_dict["last_used_data_path"] = str(new_path)
+        self._backing_dict[self.LAST_USED_DATA_KEY] = str(new_path)
         self._has_changed = True
+
+    LAST_USED_TASK_KEY = "last_used_task"
 
     @property
     def last_used_task(self) -> str:
-        key = "last_used_task"
-        val = self._backing_dict.get(key, "")
+        val = self._backing_dict.get(self.LAST_USED_TASK_KEY, "")
         return val
 
     @last_used_task.setter
     def last_used_task(self, new_task: str):
-        self._backing_dict["last_used_task"] = new_task
+        self._backing_dict[self.LAST_USED_TASK_KEY] = new_task
 
     ## Autosaving Management ##
     SAVE_ON_ITER_KEY = "save_on_iter"
@@ -148,6 +151,7 @@ class UserConfig:
         # Only do the (relatively) expensive I/O when we have changes
         if self._has_changed:
             self._cart_config.save()
+
 
 class CARTConfig:
     """

--- a/CART/CARTLib/utils/config.py
+++ b/CART/CARTLib/utils/config.py
@@ -93,6 +93,10 @@ class UserConfig:
         # Track whether something has changed, so other processes can reference it
         self._has_changed = False
 
+    @property
+    def has_changed(self):
+        return self._has_changed
+
     ## Last Used Settings ##
     LAST_USED_COHORT_KEY = "last_used_cohort_file"
 

--- a/CART/CARTLib/utils/config.py
+++ b/CART/CARTLib/utils/config.py
@@ -145,7 +145,9 @@ class UserConfig:
         prompt.exec()
         
     def save_to_file(self):
-        self._cart_config.save()
+        # Only do the (relatively) expensive I/O when we have changes
+        if self._has_changed:
+            self._cart_config.save()
 
 class CARTConfig:
     """

--- a/CART/CARTLib/utils/default_config.json
+++ b/CART/CARTLib/utils/default_config.json
@@ -1,7 +1,11 @@
 {
   "last_user": "Default",
+  "user_roles": [
+    "N/A"
+  ],
   "user_profiles": {
     "Default": {
+      "role": "N/A",
       "save_on_iter": true
     }
   }

--- a/CART/CARTLib/utils/default_config.json
+++ b/CART/CARTLib/utils/default_config.json
@@ -1,4 +1,8 @@
 {
-  "users": [],
-  "save_on_iter": true
+  "last_user": "Default",
+  "user_profiles": {
+    "Default": {
+      "save_on_iter": true
+    }
+  }
 }

--- a/CART/CARTLib/utils/default_config.json
+++ b/CART/CARTLib/utils/default_config.json
@@ -1,5 +1,4 @@
 {
   "users": [],
-  "autosave": true,
-  "autosave_frequency": 120
+  "save_on_iter": true
 }


### PR DESCRIPTION
## Description

This PR aims to address a few concerns discussed during some of our internal discussions, as well as some shortcomings discovered during development. Namely:

* Make configuration specific to the active user (user "profiles")
* Extend the metadata that is tracked for each user
* Add a GUI for the user to change their configuration in-app.

### Change Log

The specific changes made in this PR are summarized as follows:

* Added configuration button and corresponding GUI to change the configuration of CART in-app
* Split the global configuration (`Config`) into two sub-configs (`CARTConfig` and `UserConfig`)
  * The former tracks which user previously used CART, so they can be restored on-load.
  * The latter tracks user-specific configuration options, which are loaded and referenced throughout the program.
* Moved the following configuration fields to be per-user:
  * Last-used Data Path
  * Last-used Cohort
  * Last-used Task
  * Whether CART should try and auto-save on iteration 
* New configuration option per user: "Role"
  * Arbitrary label which allows the user to describe what they are (i.e. "Clinician", "Student" etc.).
  * New users can select from previously registered roles, or create a new one.
  * Existing users can change their role through their configuration.
* Improved compliance with Slicer's module design standards:
  * Moved all `Task` related functionality within `CARTWidget` into `CARTLogic`
  * Improved `CARTLogic` data access via Python properties
* Tasks now receive the user's config to reference, rather than just their username, to reference
  * Update all "example" tasks to use this new system
* Tasks can now create "sub-configs", also on a per-user basis
  * A very simple implementation of this was added to the MultiContrast Segmentation Review task.
* Several naming and structural changes
  * Renamed `TaskBaseClass.autosave` to `TaskBaseClass.save_on_iter` to better reflect its actual use
  * `utils.config.config` is now `utils.config.GLOBAL_CONFIG` to help it stand out
  * Moved several duplicated strings to constant variables which can be referenced outside their home class

## Checklist

Before the PR is accepted, all of these bullet points should be completed. If one is not relevant to your code base (i.e. a bug fix probably doesn't need a documentation update), feel free to delete the bullet point instead.

- [x] **Documentation Update**: The documentation (including code comments!) has been updated to reflect the changes.
- [x] **GUI Workflow Testing**: I've run through common use cases of CART's GUI to ensure they were not affected by these changes.
- [x] **Project Status**: I've linked to relevant [issues](https://github.com/SomeoneInParticular/CART/issues), and updated their [project status](https://github.com/users/SomeoneInParticular/projects/2) to reflect their work-in-progress/in-review status.

## Linked Issues

N/A, in review.

## Other Remarks

A follow-up PR will be made to further extend per-task configuration options (extending the Multi-Contrast task's config, as well as implementing it for other example tasks). 
