### PR TITLE
Change output segmentation name to add suffix to volume name

### DIFF
--- a/CART/CARTLib/core/DataManager.py
+++ b/CART/CARTLib/core/DataManager.py
@@ -317,6 +317,7 @@ class DataManager:
             return self.get_data_unit(idx)
 
         # If we somehow lack a UID, raise an error
+        case_data = self.case_data[idx]
         uid = self.case_data[idx].get("uid")
         if uid is None:
             raise ValueError("Tried to get a data unit for a case without a UID!")
@@ -324,7 +325,7 @@ class DataManager:
         # Using the reference task, generate our prior data and build the corresponding data unit
         prior_data = None
         if self.reference_task is not None:
-            prior_data = self.reference_task.generate_prior_data_for(uid)
+            prior_data = self.reference_task.generate_prior_data_for(case_data)
         return self.get_data_unit(idx, prior_data)
 
     def current_data_unit(self) -> DataUnitBase:

--- a/CART/CARTLib/core/TaskBaseClass.py
+++ b/CART/CARTLib/core/TaskBaseClass.py
@@ -177,7 +177,7 @@ class TaskBaseClass(ABC, Generic[D]):
         else:
             raise ValueError(f"An error occurred during saving: {save_result}")
 
-    def generate_prior_data_for(self, uid: str) -> Optional[dict]:
+    def generate_prior_data_for(self, case_data: dict) -> Optional[dict]:
         """
         Return a dictionary containing data required to re-load previous
         outputs for a case.

--- a/CART/CARTLib/examples/Segmentation/SegmentationIO.py
+++ b/CART/CARTLib/examples/Segmentation/SegmentationIO.py
@@ -191,8 +191,19 @@ class SegmentationIO:
     def _generate_output_paths_for(self, uid: str, seg_name: str, input_volume_path: Optional[Path] = None):
         # TODO: Allow user-configurable file structure
 
-        # Determine the output file destinations
-        stem_path = self.job_config.output_path / uid
+        # If this is a NIfTI format, try to place the outputs in roughly BIDS-compliant format
+        if self.task_config.file_format == SegmentationFileFormat.NIFTI:
+            # Split the "subject" and "session" parts of the UID, if they're present
+            if "sub" in uid and "ses" in uid:
+                sub, ses = uid.split("__")  # TODO: Define this "magic" string somewhere explicitly
+                stem_path = self.job_config.output_path / sub / ses
+            # Otherwise, use the UID "raw"
+            else:
+                stem_path = self.job_config.output_path / uid
+            # Add an "anat" dir to the end
+            stem_path /= "anat"
+        else:
+            stem_path = self.job_config.output_path / uid
 
         # Derive the file stem from the input volume name when available, so
         # that BIDS entities such as acq-* and the modality suffix (e.g. _T2w)

--- a/CART/CARTLib/examples/Segmentation/SegmentationIO.py
+++ b/CART/CARTLib/examples/Segmentation/SegmentationIO.py
@@ -119,10 +119,16 @@ class SegmentationIO:
         return log_data
 
     ## Save/Load Management ##
-    def is_case_done(self, uid: str):
+    def is_case_done(self, uid: str, input_volume_path: Optional[Path] = None):
         """
         Check whether the expected output files for the given case
         UID exist or not.
+
+        :param uid: The case UID to check.
+        :param input_volume_path: Path to the source volume file. When provided,
+            BIDS entities beyond the uid (e.g. acq-*, modality suffix) are
+            included in the expected output filename, matching what
+            _generate_output_paths_for would produce at save time.
         """
         # If our log file doesn't have an entry, return None
         log_entry = self.log_data.get(uid)
@@ -142,7 +148,7 @@ class SegmentationIO:
             for seg_id in saved_keys.split(", "):
                 # Get the "final" name for this segmentation
                 seg_name = EditableSegmentationResource.get_short_name(seg_id)
-                nifti_path = self._generate_output_paths_for(uid, seg_name)
+                nifti_path = self._generate_output_paths_for(uid, seg_name, input_volume_path)
                 if not nifti_path.exists():
                     return False
                 # If it's a NIfTI file, check for the sidecar as well
@@ -153,9 +159,15 @@ class SegmentationIO:
 
         return True
 
-    def get_saved_segmentation_paths(self, uid: str):
+    def get_saved_segmentation_paths(self, uid: str, input_volume_path: Optional[Path] = None):
         """
-        Get the case name -> output path map for this case
+        Get the case name -> output path map for this case.
+
+        :param uid: The case UID to look up.
+        :param input_volume_path: Path to the source volume file. When provided,
+            BIDS entities beyond the uid (e.g. acq-*, modality suffix) are
+            included in the expected output filename, matching what
+            _generate_output_paths_for would produce at save time.
         """
         unit_data = self.log_data.get(uid, {})
         saved_keys = unit_data.get(self.SAVED_KEY, '')
@@ -167,7 +179,7 @@ class SegmentationIO:
         segmentation_paths = {}
         for seg_name in saved_keys.split(", "):
             # Find where the file should be, skipping it if one does not exist
-            nifti_path = self._generate_output_paths_for(uid, seg_name)
+            nifti_path = self._generate_output_paths_for(uid, seg_name, input_volume_path)
             if not nifti_path.is_file():
                 continue
             # Track the file within the dictionary
@@ -176,12 +188,30 @@ class SegmentationIO:
 
         return segmentation_paths
 
-    def _generate_output_paths_for(self, uid: str, seg_name: str):
+    def _generate_output_paths_for(self, uid: str, seg_name: str, input_volume_path: Optional[Path] = None):
         # TODO: Allow user-configurable file structure
 
         # Determine the output file destinations
         stem_path = self.job_config.output_path / uid
-        file_name = f"{uid}_{seg_name}"
+
+        # Derive the file stem from the input volume name when available, so
+        # that BIDS entities such as acq-* and the modality suffix (e.g. _T2w)
+        # are preserved in the output filename.
+        #
+        # Example:
+        #   input : sub-001_ses-20111118_acq-axCerv_T2w.nii.gz
+        #   output: sub-001_ses-20111118_acq-axCerv_T2w_label-lesion_seg.nii.gz
+        if input_volume_path is not None:
+            # Strip one or two extensions to handle both .nii.gz and .nii
+            volume_stem = input_volume_path.name
+            for ext in (".nii.gz", ".nii", ".nrrd"):
+                if volume_stem.endswith(ext):
+                    volume_stem = volume_stem[: -len(ext)]
+                    break
+            file_name = f"{volume_stem}_{seg_name}"
+        else:
+            # Fallback: use only the uid (original behaviour)
+            file_name = f"{uid}_{seg_name}"
 
         # Define the NIfTI file paths
         if self.task_config.file_format == SegmentationFileFormat.NIFTI:
@@ -274,8 +304,19 @@ class SegmentationIO:
         :return: The output path of the MAIN (.nii.gz) saved file
         :raises ValueError: If the values provided would result in a corrupted save file.
         """
+        # Resolve the input volume path so _generate_output_paths_for can
+        # include all BIDS entities (acq-*, modality suffix, etc.) in the
+        # output filename.
+        input_volume_path: Optional[Path] = None
+        if unit.reference_volume_node is not None:
+            storage_node = unit.reference_volume_node.GetStorageNode()
+            if storage_node is not None:
+                file_name = storage_node.GetFileName()
+                if file_name:
+                    input_volume_path = Path(file_name)
+
         # Determine the output file destinations
-        output_path = self._generate_output_paths_for(unit.uid, seg_name)
+        output_path = self._generate_output_paths_for(unit.uid, seg_name, input_volume_path)
 
         # Save everything
         if self.task_config.file_format == SegmentationFileFormat.NIFTI:

--- a/CART/CARTLib/examples/Segmentation/SegmentationTask.py
+++ b/CART/CARTLib/examples/Segmentation/SegmentationTask.py
@@ -6,6 +6,7 @@ import qt
 from CARTLib.core.TaskBaseClass import CARTTask
 from CARTLib.core.DataUnitBase import DataUnitFactory
 from CARTLib.utils.config import MasterProfileConfig, JobProfileConfig
+from CARTLib.utils.data import VolumeResource, ReferenceVolumeResource
 from CARTLib.utils.task import cart_task
 
 from SegmentationConfig import SegmentationConfig
@@ -115,11 +116,40 @@ class SegmentationTask(
 
     ## State Management ##
     def isTaskComplete(self, case_data: dict[str, str]) -> bool:
-        # Delegate to our IO manager
+        # Ensure there's a valid UI
         uid = case_data.get("uid", None)
         if uid is None:
             return False
-        return self.io.is_case_done(uid)
+
+        # Identify the reference volume path for this case
+        reference_path = None
+        for k, v in case_data.items():
+            # Skip blanks; they're not valid
+            if v is None or v == "":
+                continue
+            # Skip over non-volume entries as well
+            if not VolumeResource.is_type(k):
+                continue
+            # Skip over paths which don't exist
+            p = Path(v)
+            if not p.is_absolute():
+                p = self.job_profile.data_path / p
+            if not p.exists():
+                continue
+            # Track the first valid volume we found as a fallback
+            if reference_path is None:
+                reference_path = p
+            # If this is a valid reference volume, end here
+            if ReferenceVolumeResource.is_type(k):
+                reference_path = p
+                break
+
+        # If there isn't one, assume the case is not complete
+        if reference_path is None:
+            return False
+
+        # Delegate to our IO manager
+        return self.io.is_case_done(uid, reference_path)
 
     def save(self) -> Optional[str]:
         # Try to save the data unit

--- a/CART/CARTLib/examples/Segmentation/SegmentationTask.py
+++ b/CART/CARTLib/examples/Segmentation/SegmentationTask.py
@@ -115,12 +115,7 @@ class SegmentationTask(
         self.local_config.save()
 
     ## State Management ##
-    def isTaskComplete(self, case_data: dict[str, str]) -> bool:
-        # Ensure there's a valid UI
-        uid = case_data.get("uid", None)
-        if uid is None:
-            return False
-
+    def _find_reference_volume_path(self, case_data: dict):
         # Identify the reference volume path for this case
         reference_path = None
         for k, v in case_data.items():
@@ -144,6 +139,17 @@ class SegmentationTask(
                 reference_path = p
                 break
 
+        return reference_path
+
+    def isTaskComplete(self, case_data: dict[str, str]) -> bool:
+        # Ensure there's a valid UI
+        uid = case_data.get("uid", None)
+        if uid is None:
+            return False
+
+        # Identify the reference volume path for this case
+        reference_path = self._find_reference_volume_path(case_data)
+
         # If there isn't one, assume the case is not complete
         if reference_path is None:
             return False
@@ -157,9 +163,19 @@ class SegmentationTask(
             self.logger.error("Could not save, no data unit has been loaded!")
         self.io.save_unit(self.data_unit)
 
-    def generate_prior_data_for(self, uid: str) -> Optional[dict]:
+    def generate_prior_data_for(self, case_data: dict) -> Optional[dict]:
+        # Ensure there's a valid UI
+        uid = case_data.get("uid", None)
+        if uid is None:
+            return None
+
+        # Find the reference volume for this case
+        reference_path = self._find_reference_volume_path(case_data)
+        if reference_path is None:
+            return None
+
         # Delegate to our IO instance
-        return self.io.get_saved_segmentation_paths(uid)
+        return self.io.get_saved_segmentation_paths(uid, reference_path)
 
     def setup(self, container: qt.QWidget):
         """


### PR DESCRIPTION
This pull request updates the segmentation I/O logic to ensure that output filenames consistently include all relevant BIDS entities (such as acquisition and modality suffixes) from the input volume filename, improving traceability and compatibility with BIDS standards. The changes propagate the input volume path through key methods and update filename generation accordingly.

**Enhancements to output filename generation and method signatures:**

* Updated `is_case_done`, `get_saved_segmentation_paths`, and `_generate_output_paths_for` methods to accept an optional `input_volume_path` parameter, allowing output filenames to include BIDS entities from the input file. [[1]](diffhunk://#diff-ec59ae3dacc478973228b2eed39730a6bbba5340bbab3d775a26aa8c9c50ba21L122-R131) [[2]](diffhunk://#diff-ec59ae3dacc478973228b2eed39730a6bbba5340bbab3d775a26aa8c9c50ba21L156-R170) [[3]](diffhunk://#diff-ec59ae3dacc478973228b2eed39730a6bbba5340bbab3d775a26aa8c9c50ba21L179-R213)
* Modified `_generate_output_paths_for` to derive the output filename stem from the input volume name when available, preserving BIDS entities such as acquisition and modality suffixes in the output filenames.
* Updated all internal calls to `_generate_output_paths_for` within `is_case_done`, `get_saved_segmentation_paths`, and `_save_segmentation` to pass the `input_volume_path` when available, ensuring consistent filename generation throughout the workflow. [[1]](diffhunk://#diff-ec59ae3dacc478973228b2eed39730a6bbba5340bbab3d775a26aa8c9c50ba21L145-R151) [[2]](diffhunk://#diff-ec59ae3dacc478973228b2eed39730a6bbba5340bbab3d775a26aa8c9c50ba21L170-R182) [[3]](diffhunk://#diff-ec59ae3dacc478973228b2eed39730a6bbba5340bbab3d775a26aa8c9c50ba21R307-R319)

Fixes #154 